### PR TITLE
Add Arabic to the supported language list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,5 @@ The possible languages are as follows, the default is `enUS`
 `frFR` - Français (France)\
 `deDE` - Deutsch\
 `itIT` - Italiano\
-`ruRU` - Русский
+`ruRU` - Русский\
+`arME` - العربية

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ let argv = yargs
   .alias('q', 'quality')
 
   .describe('language', 'The language of the episode subtitles')
-  .choices('language', ['enUS', 'enGB', 'esLA', 'esES', 'ptBR', 'ptPT', 'frFR', 'deDE', 'itIT', 'ruRU'])
+  .choices('language', ['enUS', 'enGB', 'esLA', 'esES', 'ptBR', 'ptPT', 'frFR', 'deDE', 'itIT', 'ruRU', 'arME'])
   .default('language', 'enUS')
   .alias('l', 'language')
 


### PR DESCRIPTION
Crunchyroll supports Arabic language.

I have tested this on my local machine, it works properly.