### PR TITLE
Add support for custom FFMPEG arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Downloads the Crunchyroll videos with the subtitles hardsubbed or softsubbed.
     - `:ep` the episode number
     - `:series` the series name
 ` `--vilos` fetch the videos/subtitles from the Crunchyroll web page. will not work with the unblocked option.
+- `--ffmpeg`, `-f` specify custom FFMPEG arguments (default: `-c copy`)
+  - examples
+    - `-f="-c copy" -f="-crf 24" -ffmpeg="-vcodec libx264"`
+    - `-f="-vf scale=-1:720"`
 
 **Downloading with Softsubs**
 - `--language` (same as above) which subtitle languages to download. if omitted, will present a list to select from. same options as below for the languages

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Downloads the Crunchyroll videos with the subtitles hardsubbed or softsubbed.
   - examples
     - `-f="-c copy" -f="-crf 24" -ffmpeg="-vcodec libx264"`
     - `-f="-vf scale=-1:720"`
+- `--overwrite` force overwrite existing files.
 
 **Downloading with Softsubs**
 - `--language` (same as above) which subtitle languages to download. if omitted, will present a list to select from. same options as below for the languages

--- a/index.js
+++ b/index.js
@@ -98,7 +98,10 @@ let argv = yargs
 
   .describe('debug', 'Prints debug information to the log')
   .boolean('debug')
-
+    
+  .describe('ffmpeg', 'Use different arguments for FFMPEG (ex. -f="-c copy" -f="-crf 24" -f="-vcodec libx265" ...)')
+  .alias('f', 'ffmpeg')
+  .default('ffmpeg', '-c copy')  
   // help
   .describe('h', 'Shows this help')
   .alias('h', 'help')
@@ -122,6 +125,7 @@ const downloadAll = argv['download-all']
 const ignoreDubs = argv['ignore-dubs']
 const episodeRanges = argv['episodes'].toString()
 const language = argv.language
+let ffmpegArgs = argv['ffmpeg']
 let desiredLanguages = language.split(',').map(l => l.trim())
 
 if (language !== 'all' && language !== 'none') {
@@ -757,6 +761,8 @@ const parsem3u8 = (manifest) => {
 }
 
 const downloadEpisode = (url, output, logDownload = true) => {
+  //ffmpegArgs = ffmpegArgs[0]
+  console.log(ffmpegArgs) //TEMP
   return new Promise((resolve, reject) => {
     ffmpeg(url)
       .on('start', () => {
@@ -773,7 +779,7 @@ const downloadEpisode = (url, output, logDownload = true) => {
         if (logDownload) info(`Successfully downloaded "${output}"`)
         resolve()
       })
-      .outputOptions('-c copy')
+      .outputOptions(ffmpegArgs)
       .output(output)
       .run()
   })

--- a/index.js
+++ b/index.js
@@ -766,8 +766,9 @@ const parsem3u8 = (manifest) => {
 
 const downloadEpisode = (url, output, logDownload = true) => {
   if(fs.existsSync(output) && !overwrite)
-    return new Promise(() => {
+    return new Promise((resolve) => {
       info("File already exists, skipping...");
+      resolve()
     })
   return new Promise((resolve, reject) => {
     ffmpeg(url)

--- a/index.js
+++ b/index.js
@@ -761,8 +761,6 @@ const parsem3u8 = (manifest) => {
 }
 
 const downloadEpisode = (url, output, logDownload = true) => {
-  //ffmpegArgs = ffmpegArgs[0]
-  console.log(ffmpegArgs) //TEMP
   return new Promise((resolve, reject) => {
     ffmpeg(url)
       .on('start', () => {

--- a/index.js
+++ b/index.js
@@ -101,7 +101,10 @@ let argv = yargs
     
   .describe('ffmpeg', 'Use different arguments for FFMPEG (ex. -f="-c copy" -f="-crf 24" -f="-vcodec libx265" ...)')
   .alias('f', 'ffmpeg')
-  .default('ffmpeg', '-c copy')  
+  .default('ffmpeg', '-c copy')
+    
+    .describe("overwrite", "Overwrite existing files")
+    .boolean("overwrite")
   // help
   .describe('h', 'Shows this help')
   .alias('h', 'help')
@@ -125,7 +128,8 @@ const downloadAll = argv['download-all']
 const ignoreDubs = argv['ignore-dubs']
 const episodeRanges = argv['episodes'].toString()
 const language = argv.language
-let ffmpegArgs = argv['ffmpeg']
+const ffmpegArgs = argv['ffmpeg']
+const overwrite = argv['overwrite']
 let desiredLanguages = language.split(',').map(l => l.trim())
 
 if (language !== 'all' && language !== 'none') {
@@ -761,6 +765,10 @@ const parsem3u8 = (manifest) => {
 }
 
 const downloadEpisode = (url, output, logDownload = true) => {
+  if(fs.existsSync(output) && !overwrite)
+    return new Promise(() => {
+      info("File already exists, skipping...");
+    })
   return new Promise((resolve, reject) => {
     ffmpeg(url)
       .on('start', () => {


### PR DESCRIPTION
This adds support for custom FFMPEG arguments.  I added the argument to the `--help` page and the README file (with examples).

Every `-f=""` is one FFMPEG argument, they CANNOT be combined such as `-f="-c copy -crf 24"`, this will cause FFMPEG to return a non-zero exit code.

Examples:
- `-f="-c copy"`
- `--ffmpeg="-c copy" --ffmpeg="-crf 24"`
- `-f="-c copy" -f="-crf 24"`
- `-f="-vcodec libx265" -f="-crf 27"`

The changes to index.js are minimal, so there shouldn't be any conflicts.

The reason I am adding this is because it saves time if you compress the video when it is downloading rather than compressing the video later (or whatever you are doing with the video).

Another reason is that using `-f="-crf 27"` will significantly reduce the download size of the video while still (mostly) retaining the quality.

Additionally, I added a no overwrite feature and an argument to force overwrite.