### PR TITLE
Argument for having episodes in a directory with their respective season name

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Downloads the Crunchyroll videos with the subtitles hardsubbed or softsubbed.
 - `--vilos` fetch the videos/subtitles from the Crunchyroll web page. will not work with the unblocked option.
 - `--ffmpeg`, `-f` specify custom FFMPEG arguments (default: `-c copy`)
   - examples
-    - `-f="-c copy" -f="-crf 24" -ffmpeg="-vcodec libx264"`
+    - `-f="-c copy" -f="-crf 24" --ffmpeg="-vcodec libx264"`
     - `-f="-vf scale=-1:720"`
 - `--overwrite` force overwrite existing files.
 - `--folderBySeason` use a specific folder for each season.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Downloads the Crunchyroll videos with the subtitles hardsubbed or softsubbed.
     - `-f="-c copy" -f="-crf 24" -ffmpeg="-vcodec libx264"`
     - `-f="-vf scale=-1:720"`
 - `--overwrite` force overwrite existing files.
+- `--folderBySeason` use a specific folder for each season.
+- `--moveExists` move existing files to their season folder.
 
 **Downloading with Softsubs**
 - `--language` (same as above) which subtitle languages to download. if omitted, will present a list to select from. same options as below for the languages

--- a/index.js
+++ b/index.js
@@ -109,6 +109,9 @@ let argv = yargs
   .describe("folderBySeason", "Put episodes into folders by their seasons")
   .boolean("folderBySeason")
     
+  .describe("moveExists", "Move existing files to their season folder (used for merging with folderBySeason) (REQUIRES folderBySeason to be on)")
+  .boolean("moveExists")
+    
   // help
   .describe('h', 'Shows this help')
   .alias('h', 'help')
@@ -135,6 +138,7 @@ const language = argv.language
 const ffmpegArgs = argv['ffmpeg']
 const overwrite = argv['overwrite']
 const folderBySeason = argv["folderBySeason"]
+let moveExists = argv['moveExists']
 let seasonName = "null";
 let desiredLanguages = language.split(',').map(l => l.trim())
 
@@ -146,6 +150,11 @@ if (language !== 'all' && language !== 'none') {
       process.exit(1)
     }
   }
+}
+
+if(moveExists && !folderBySeason) {
+  warn("moveExists has been disabled because folderBySeason is disabled.")
+  moveExists = false;
 }
 
 if (subsOnly && subType !== 'soft') {
@@ -792,10 +801,19 @@ const parsem3u8 = (manifest) => {
 }
 
 const downloadEpisode = (url, output, logDownload = true) => {
+  
   if(folderBySeason) {
     const fs = require("fs");
     if(!fs.existsSync(seasonName))
       fs.mkdirSync(seasonName)
+    if(fs.existsSync(output) && moveExists)
+      return new Promise((resolve) => {
+        info("Moving " + output + " to " + seasonName + "/" + output);
+        fs.rename(output, "./" + seasonName + "/" + output, foo => {
+          
+        })
+        resolve()
+      })
     output = "./" + seasonName + "/" + output;
   }
   if(fs.existsSync(output) && !overwrite)

--- a/index.js
+++ b/index.js
@@ -792,20 +792,19 @@ const parsem3u8 = (manifest) => {
 }
 
 const downloadEpisode = (url, output, logDownload = true) => {
-  console.log(output) //TEMP
+  if(folderBySeason) {
+    const fs = require("fs");
+    if(!fs.existsSync(seasonName))
+      fs.mkdirSync(seasonName)
+    output = "./" + seasonName + "/" + output;
+  }
   if(fs.existsSync(output) && !overwrite)
     return new Promise((resolve) => {
       info("File already exists, skipping...");
       resolve()
     })
   return new Promise((resolve, reject) => {
-    if(folderBySeason) {
-      const fs = require("fs");
-      if(!fs.existsSync(seasonName))
-        fs.mkdirSync(seasonName)
-      process.chdir("./" + seasonName)
-      output = "./" + seasonName + "/" + output;
-    }
+    
     ffmpeg(url)
       .on('start', () => {
         info('Beginning download...')
@@ -824,8 +823,6 @@ const downloadEpisode = (url, output, logDownload = true) => {
       .outputOptions(ffmpegArgs)
       .output(output)
       .run()
-    if(folderBySeason)
-      process.chdir("..")
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -809,9 +809,7 @@ const downloadEpisode = (url, output, logDownload = true) => {
     if(fs.existsSync(output) && moveExists)
       return new Promise((resolve) => {
         info("Moving " + output + " to " + seasonName + "/" + output);
-        fs.rename(output, "./" + seasonName + "/" + output, foo => {
-          
-        })
+        fs.rename(output, "./" + seasonName + "/" + output, () => {})
         resolve()
       })
     output = "./" + seasonName + "/" + output;


### PR DESCRIPTION
This will allow users to download series separated by season names.

Example:
```
//with --folderBySeason

anime
    Season1
        Episode1 of Season1
        Episode2 of Season1
        Episode3 of Season1
    Season2
        Episode1 of Season2
        Episode2 of Season2
        Episode3 of Season2

//without --folderBySeason
anime
    Episode1 of Season1
    Episode1 of Season2
    Episode2 of Season1
    Episode2 of Season2
    Episode3 of Season1
    Episode3 of Season2
```

This should not mess with anything, but I will allow edits in case something is wrong.

Edit:  I have also included a tool to move anime that already exist to the new folder (for people that are using this tool for automation)