### PR TITLE
PM2 may have problems with cursorTo()

### DIFF
--- a/lib/bar.js
+++ b/lib/bar.js
@@ -10,9 +10,12 @@ module.exports = (percent, fps, timemark, type = 'Downloading') => {
   // calculate 3 dots
   let dotsCount = (Number(Number(percent).toFixed()) % 3) + 1
   let downloadingStr = `${c.bold(`${type}${'.'.repeat(dotsCount)}`)}${' '.repeat(3 - dotsCount)}`
-
   let str = `${c.bold.cyan('i')} ${downloadingStr} ${percentStr} ${fpsStr} ${timemarkStr}`
-  stream.cursorTo(0)
-  stream.write(str)
-  stream.clearLine(1)
+  try {
+    stream.cursorTo(0)
+    stream.write(str)
+    stream.clearLine(1)
+  } catch(ignored) {
+    console.log(str)
+  }
 }


### PR DESCRIPTION
Fixes `TypeError: stream.cursorTo is not a function` when using [PM2](https://github.com/Unitech/pm2)