### PR TITLE
Fix some problems (not CF bypass though)

### DIFF
--- a/index.js
+++ b/index.js
@@ -787,7 +787,7 @@ const parsem3u8 = (manifest) => {
 const downloadEpisode = (url, output, logDownload = true) => {
   if(fs.existsSync(output) && !overwrite)
     return new Promise((resolve) => {
-      info("File already exists, skipping...");
+      info("File already exists, skipping...")
       resolve()
     })
   return new Promise((resolve, reject) => {

--- a/index.js
+++ b/index.js
@@ -581,7 +581,7 @@ const main = async () => {
       if (e.errorType === 1) {
         error('Cannot solve CAPTCHA automatically! Please try again later.')
       }
-      await cleanup()
+      await cleanup(false, true, true, 5)
     }
     const idDivRegex = /<div class="show-actions" group_id="(.*)"><\/div>/ // search for a div with an id
 

--- a/index.js
+++ b/index.js
@@ -243,7 +243,7 @@ const main = async () => {
     const { data: { data: sessionData } } = await crunchyrollRequest('get', 'start_session.0.json', {
       params: {
         access_token: 'WveH9VkPLrXvuNm',
-        device_type: 'com.crunchyroll.crunchyroid',
+        device_type: 'com.crunchyroll.windows.desktop',
         device_id: uuid(),
         ...baseParams
       }

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const axios = require('axios')
 const uuid = require('uuid')
 const FormData = require('form-data')
 const cloudscraper = require('cloudscraper')
+const youtubedl = require('youtube-dl')
 
 const sanitize = require('sanitize-filename')
 const ffmpeg = require('fluent-ffmpeg')
@@ -361,8 +362,18 @@ const main = async () => {
   
         mediaHandler = await getMedia(xmlData)
         streams = [{ url: mediaHandler.getStream().getFile() }]
-        subtitles = mediaHandler.getSubtitles()
-
+        //subtitles = mediaHandler.getSubtitles()
+        
+        const ytdlSubsArgs = {
+          auto: false,
+          all: false,
+          format: 'ass',
+          lang: language,
+          cwd: tmpDir || './tmp/'
+        }
+        
+        let subtitles = youtubedl.getSubs("")
+        
         let subtitleContent = await Promise.all(subtitles.map(async (subtitle) => await subtitle.getContent()))
 
         choices = subtitleContent.map((sub) => ({ title: sub.title, value: sub, locale: sub.locale.replace('-', '') }))

--- a/index.js
+++ b/index.js
@@ -215,7 +215,7 @@ const main = async () => {
   // start session, either unblocked or blocked
   if (unblocked) {
     try {
-      const { data: { data: unblockedSessionData } } = await axios.get('https://api2.cr-unblocker.com/start_session', {
+      const { data: { data: unblockedSessionData } } = await axios.get('https://cr-unblocker.us.to/start_session', {
         params: {
           device_id: uuid(),
           version: '1.1'

--- a/index.js
+++ b/index.js
@@ -259,7 +259,7 @@ const main = async () => {
     const { data: { data: sessionData } } = await crunchyrollRequest('get', 'start_session.0.json', {
       params: {
         access_token: 'WveH9VkPLrXvuNm',
-        device_type: 'com.crunchyroll.crunchyroid',
+        device_type: 'com.crunchyroll.crunchyroid', //com.crunchyroll.windows.desktop has problems
         device_id: uuid(),
         ...baseParams
       }

--- a/index.js
+++ b/index.js
@@ -243,7 +243,7 @@ const main = async () => {
     const { data: { data: sessionData } } = await crunchyrollRequest('get', 'start_session.0.json', {
       params: {
         access_token: 'WveH9VkPLrXvuNm',
-        device_type: 'com.crunchyroll.windows.desktop',
+        device_type: 'com.crunchyroll.crunchyroid',
         device_id: uuid(),
         ...baseParams
       }

--- a/index.js
+++ b/index.js
@@ -443,7 +443,7 @@ const main = async () => {
           return
         }
       } else {
-        if(language !== "none" && !noLang) {
+        if(!noLang) {
           info(`Downloading subtitle languages: ${selectedLanguages.map(sub => sub.title).join(', ')}`)
           subtitles = await downloadSubs(subPath, selectedLanguages, vilos)
           info('Subtitles downloaded!')

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "sanitize-filename": "^1.6.3",
     "treeify": "^1.1.0",
     "uuid": "^3.3.3",
-    "yargs": "^14.0.0",
-    "youtube-dl": "^3.0.2"
+    "yargs": "^14.0.0"
   },
   "bin": {
     "crunchyroll-dl": "index.js"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "sanitize-filename": "^1.6.3",
     "treeify": "^1.1.0",
     "uuid": "^3.3.3",
-    "yargs": "^14.0.0"
+    "yargs": "^14.0.0",
+    "youtube-dl": "^3.0.2"
   },
   "bin": {
     "crunchyroll-dl": "index.js"


### PR DESCRIPTION
patch-3 pull request fixes the following:
-	[x] Overwriting soft-sub episodes (would not check before).
-	[x] #44 - change unblock server (not sure if this is a good idea to merge, I can remove it if you want).
-	[x] #53 - downloading without subs still downloads English subs.  Requires the vilos argument and the new `--noLang` argument.  Will automatically enable soft subs but will not auto-enable vilos.
	

Known bugs:
- Windows 10 and some non-Bash terminals do not show the percentage downloaded.  This is a minor bug that does not effect the downloader.
- The CF anti-bot page will (still) block the program sometimes.  I am looking into fixing this, but I'm not sure I will be able to do anything about it.  You can sort of fix this by going on CR and playing a video, exiting, then downloading, but this is not guaranteed to work and can be annoying.
- Downloading without subs does not work without vilos (major) or with hard subs (minor).

Other notes:
- I noticed that downloading individual episodes bypassed the anti-bot page 100% of the time opposed to downloading an entire series.  If there is a way to get the individual episode URLs then it may be possible to bypass the CF page (for now at least).
- The `--noLang` parameter has been added for #53, must be used with vilos.  This doesn't appear to be a new bug, the subtitles do not appear to download normally without vilos.
- The `--noLang` tag will have to be added to the README.
- Feel free to edit my fork or suggest edits.